### PR TITLE
`defaultValues` を開始時に流さないように変更

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,10 +19,6 @@ export type Params<Features extends Dictionary> = Readonly<{
      */
     decoder: Decoder<unknown, Features>;
     /**
-     * The default values of the feature flags.
-     */
-    defaultValues: Features;
-    /**
      * The client-side ID.
      */
     envKey: LDParams[0];
@@ -41,7 +37,6 @@ export type Params<Features extends Dictionary> = Readonly<{
  */
 export function makeLaunchDarklyDriver<Features extends Dictionary>({
     decoder,
-    defaultValues,
     envKey,
     options,
     user,
@@ -80,7 +75,7 @@ export function makeLaunchDarklyDriver<Features extends Dictionary>({
             async stop() {
                 await client?.close();
             },
-        }).startWith(defaultValues),
+        }),
     });
 }
 


### PR DESCRIPTION
今までは開始時に `startWith` で `defaultValues` を流していましたが、いったん仮の値で表示されたあと、遅れてやってきた実際の値で描画をやり直すため、レイアウトに関わるfeature flagがある場合にCLSが発生していました。

インターフェースが変わっているので、このコミットを含むリリースは `0.2.0` になるべきだと考えます。